### PR TITLE
Add work-arounds for functionality which doesn't work in TBC classic

### DIFF
--- a/VanasKoS.lua
+++ b/VanasKoS.lua
@@ -94,7 +94,10 @@ local mapID = -1
 
 function VanasKoS.hashName(name, realm)
 	assert(name)
-	assert(realm)
+	-- realm appears to be nil on TBC; skip check
+	if WOW_PROJECT_ID ~= WOW_PROJECT_BURNING_CRUSADE_CLASSIC then
+		assert(realm)
+	end
 	if strmatch(name, " ") or strmatch(name, "-") then
 		print("ignoring illegal name " .. name)
 		return nil

--- a/modules/DataGatherer.lua
+++ b/modules/DataGatherer.lua
@@ -557,18 +557,21 @@ function VanasKoSDataGatherer:Update()
 		self:EnableDataGathering(true)
 	end
 
-	if (C_PvP.IsWarModeDesired() and not self.db.profile.EnableInWarMode) then
-		self:EnableTargetEvents(false)
-		self:EnableCombatEvents(false)
-	elseif (not C_PvP.IsWarModeDesired() and not self.db.profile.EnableInNormalMode) then
-		self:EnableTargetEvents(false)
-		self:EnableCombatEvents(false)
-	end
+	-- War mode doesn't exist in TBC
+	if WOW_PROJECT_ID ~= WOW_PROJECT_BURNING_CRUSADE_CLASSIC then
+		if (C_PvP.IsWarModeDesired() and not self.db.profile.EnableInWarMode) then
+			self:EnableTargetEvents(false)
+			self:EnableCombatEvents(false)
+		elseif (not C_PvP.IsWarModeDesired() and not self.db.profile.EnableInNormalMode) then
+			self:EnableTargetEvents(false)
+			self:EnableCombatEvents(false)
+		end
 
-	if (C_PvP.IsWarModeDesired() and not self.db.profile.GatherInWarMode) then
-		self:EnableDataGathering(false)
-	elseif (not C_PvP.IsWarModeDesired() and not self.db.profile.GatherInNormalMode) then
-		self:EnableDataGathering(false)
+		if (C_PvP.IsWarModeDesired() and not self.db.profile.GatherInWarMode) then
+			self:EnableDataGathering(false)
+		elseif (not C_PvP.IsWarModeDesired() and not self.db.profile.GatherInNormalMode) then
+			self:EnableDataGathering(false)
+		end
 	end
 end
 

--- a/modules/EventMap.lua
+++ b/modules/EventMap.lua
@@ -421,10 +421,13 @@ function VanasKoSEventMap:OnInitialize()
 
 	PINGRIDALIGN = ICONSIZE
 
-	for _, overlayFrame in next, WorldMapFrame.overlayFrames do
-		if(overlayFrame.Border and overlayFrame.Border:GetTexture() == 'Interface\\Minimap\\MiniMap-TrackingBorder') then
-			hooksecurefunc(overlayFrame, 'InitializeDropDown', VanasKoSEventMap.InitializeTrackingDropDown)
-			break
+	-- WorldMapFrame.overlayFrames seems to be nil in TBC
+	if WOW_PROJECT_ID ~= WOW_PROJECT_BURNING_CRUSADE_CLASSIC then
+		for _, overlayFrame in next, WorldMapFrame.overlayFrames do
+			if(overlayFrame.Border and overlayFrame.Border:GetTexture() == 'Interface\\Minimap\\MiniMap-TrackingBorder') then
+				hooksecurefunc(overlayFrame, 'InitializeDropDown', VanasKoSEventMap.InitializeTrackingDropDown)
+				break
+			end
 		end
 	end
 end


### PR DESCRIPTION
The retail version of vanas kos appears to work fine in TBC classic when a few sections are wrapped in if TBC statements.